### PR TITLE
Add well-known handler

### DIFF
--- a/app.go
+++ b/app.go
@@ -1,12 +1,13 @@
 package caddy_libp2p_listener
 
 import (
+	"strconv"
+
 	"github.com/caddyserver/caddy/v2"
 	"github.com/caddyserver/caddy/v2/caddyconfig"
 	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
 	"github.com/caddyserver/caddy/v2/caddyconfig/httpcaddyfile"
 	"go.uber.org/zap"
-	"strconv"
 )
 
 func init() {

--- a/example/Caddyfile
+++ b/example/Caddyfile
@@ -1,0 +1,31 @@
+{
+	auto_https off
+	servers {
+		protocols h1 h2
+	}
+	libp2p {
+		# private_key ed25519key.pem
+		advertise_amino true
+	}
+}
+
+:4002 {
+	# Site-specific options
+	bind multiaddr:/ip4/0.0.0.0/udp/4002/quic-v1/webtransport
+	bind 127.0.0.1
+	bind ::1
+
+    handle / {
+        respond "Hello World"
+    }
+
+	route /.well-known/libp2p/* {
+		well_known-libp2p {
+            # Tell peers where our protocols are mounted
+			/hello/0.0.1 => /
+		}
+	}
+
+
+	respond "I am 4002"
+}

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.21.4
 
 require (
 	github.com/caddyserver/caddy/v2 v2.8.4
-	github.com/libp2p/go-libp2p v0.35.0
+	github.com/libp2p/go-libp2p v0.35.1
 	github.com/libp2p/go-libp2p-kad-dht v0.25.2
 	github.com/multiformats/go-multiaddr v0.12.4
 	go.uber.org/zap v1.27.0
@@ -129,7 +129,7 @@ require (
 	github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58 // indirect
 	github.com/pion/datachannel v1.5.6 // indirect
 	github.com/pion/dtls/v2 v2.2.11 // indirect
-	github.com/pion/ice/v2 v2.3.24 // indirect
+	github.com/pion/ice/v2 v2.3.25 // indirect
 	github.com/pion/interceptor v0.1.29 // indirect
 	github.com/pion/logging v0.2.2 // indirect
 	github.com/pion/mdns v0.0.12 // indirect

--- a/go.sum
+++ b/go.sum
@@ -417,8 +417,8 @@ github.com/libp2p/go-cidranger v1.1.0 h1:ewPN8EZ0dd1LSnrtuwd4709PXVcITVeuwbag38y
 github.com/libp2p/go-cidranger v1.1.0/go.mod h1:KWZTfSr+r9qEo9OkI9/SIEeAtw+NNoU0dXIXt15Okic=
 github.com/libp2p/go-flow-metrics v0.1.0 h1:0iPhMI8PskQwzh57jB9WxIuIOQ0r+15PChFGkx3Q3WM=
 github.com/libp2p/go-flow-metrics v0.1.0/go.mod h1:4Xi8MX8wj5aWNDAZttg6UPmc0ZrnFNsMtpsYUClFtro=
-github.com/libp2p/go-libp2p v0.35.0 h1:1xS1Bkr9X7GtdvV6ntLnDV9xB1kNjHK1lZ0eaO6gnhc=
-github.com/libp2p/go-libp2p v0.35.0/go.mod h1:snyJQix4ET6Tj+LeI0VPjjxTtdWpeOhYt5lEY0KirkQ=
+github.com/libp2p/go-libp2p v0.35.1 h1:Hm7Ub2BF+GCb14ojcsEK6WAy5it5smPDK02iXSZLl50=
+github.com/libp2p/go-libp2p v0.35.1/go.mod h1:Dnkgba5hsfSv5dvvXC8nfqk44hH0gIKKno+HOMU0fdc=
 github.com/libp2p/go-libp2p-asn-util v0.4.1 h1:xqL7++IKD9TBFMgnLPZR6/6iYhawHKHl950SO9L6n94=
 github.com/libp2p/go-libp2p-asn-util v0.4.1/go.mod h1:d/NI6XZ9qxw67b4e+NgpQexCIiFYJjErASrYW4PFDN8=
 github.com/libp2p/go-libp2p-kad-dht v0.25.2 h1:FOIk9gHoe4YRWXTu8SY9Z1d0RILol0TrtApsMDPjAVQ=
@@ -539,8 +539,8 @@ github.com/pion/datachannel v1.5.6/go.mod h1:1eKT6Q85pRnr2mHiWHxJwO50SfZRtWHTsNI
 github.com/pion/dtls/v2 v2.2.7/go.mod h1:8WiMkebSHFD0T+dIU+UeBaoV7kDhOW5oDCzZ7WZ/F9s=
 github.com/pion/dtls/v2 v2.2.11 h1:9U/dpCYl1ySttROPWJgqWKEylUdT0fXp/xst6JwY5Ks=
 github.com/pion/dtls/v2 v2.2.11/go.mod h1:d9SYc9fch0CqK90mRk1dC7AkzzpwJj6u2GU3u+9pqFE=
-github.com/pion/ice/v2 v2.3.24 h1:RYgzhH/u5lH0XO+ABatVKCtRd+4U1GEaCXSMjNr13tI=
-github.com/pion/ice/v2 v2.3.24/go.mod h1:KXJJcZK7E8WzrBEYnV4UtqEZsGeWfHxsNqhVcVvgjxw=
+github.com/pion/ice/v2 v2.3.25 h1:M5rJA07dqhi3nobJIg+uPtcVjFECTrhcR3n0ns8kDZs=
+github.com/pion/ice/v2 v2.3.25/go.mod h1:KXJJcZK7E8WzrBEYnV4UtqEZsGeWfHxsNqhVcVvgjxw=
 github.com/pion/interceptor v0.1.29 h1:39fsnlP1U8gw2JzOFWdfCU82vHvhW9o0rZnZF56wF+M=
 github.com/pion/interceptor v0.1.29/go.mod h1:ri+LGNjRUc5xUNtDEPzfdkmSqISixVTBF/z/Zms/6T4=
 github.com/pion/logging v0.2.2 h1:M9+AIj/+pxNsDfAT64+MAVgJO0rsyLnoJKCqf//DoeY=

--- a/module.go
+++ b/module.go
@@ -93,11 +93,12 @@ func parseCaddyfile(h httpcaddyfile.Helper) (caddyhttp.MiddlewareHandler, error)
 	return &m, err
 }
 
-var _ caddy.Module = (*Libp2pHandler)(nil)
-
-var _ caddyhttp.MiddlewareHandler = (*Libp2pHandler)(nil)
-var _ caddyfile.Unmarshaler = (*Libp2pHandler)(nil)
-var _ caddy.Provisioner = (*Libp2pHandler)(nil)
+var (
+	_ caddy.Module                = (*Libp2pHandler)(nil)
+	_ caddyhttp.MiddlewareHandler = (*Libp2pHandler)(nil)
+	_ caddyfile.Unmarshaler       = (*Libp2pHandler)(nil)
+	_ caddy.Provisioner           = (*Libp2pHandler)(nil)
+)
 
 func registerMultiaddrURI(ctx context.Context, network, addr string, cfg net.ListenConfig) (any, error) {
 	cctx, ok := ctx.(caddy.Context)


### PR DESCRIPTION
Played around with this a bit and added a module to handle the `.well-known/libp2p/protocols` endpoint. The underlying idea is this enables other peers who discover us to understand what protocols we support and how to reach them. In a standard server/client deployment there is a lot of coordination on what protocol is where. With the well-known resource we can avoid this coordination and allow peers to learn about each other in a similar way to the `identify` protocol.

Example Caddyfile Usage:
```
:4002 {
	# Site-specific options
	bind multiaddr:/ip4/0.0.0.0/udp/4002/quic-v1/webtransport
	bind 127.0.0.1
	bind ::1

    handle / {
        respond "Hello World"
    }

	route /.well-known/libp2p/* {
		well_known-libp2p {
                        # Tell peers where our protocols are mounted
			/hello/0.0.1 => /
		}
	}
	respond "I am 4002"
}
```

```
$  curl 127.0.0.1:4002/.well-known/libp2p/protocols
{"/hello/0.0.1":{"path":"/"}}
```

Note that the user has to explicitly advertise protocols. I think this is okay, but could be better. I'm just not very familiar with caddy. Maybe it's possible to mark other routes/handlers with a decorator.
